### PR TITLE
Support environment variables in server config

### DIFF
--- a/artifactory_cleanup/loaders.py
+++ b/artifactory_cleanup/loaders.py
@@ -190,6 +190,7 @@ class YamlConfigLoader:
         user = config["artifactory-cleanup"]["user"]
         password = config["artifactory-cleanup"]["password"]
 
+        server = os.path.expandvars(server)
         user = os.path.expandvars(user)
         password = os.path.expandvars(password)
         return server, user, password


### PR DESCRIPTION
Expand environment variables also for `server` (similar to fields `user` and `password`) .